### PR TITLE
expanding useApi hook to support different HTTP requests 

### DIFF
--- a/src/hooks/useApi.js
+++ b/src/hooks/useApi.js
@@ -1,27 +1,59 @@
 import { useState, useEffect } from 'react';
 
-// TODO: expand this hook to take on different params so we can handle non-GET requests
-function useApi(route) {
+/*
+  Hook used to fetch API data
 
+  Params:
+    route (string) - which API route we should connect to
+    method (string) - one of the HTTP methods (GET, POST, PUT). If none provided, defaults to GET
+    body (object) - used for requests that support passing a body
+
+  Returns:
+    [
+      result (object) - data returned by the API,
+      loading (boolean) - used for loading indicator
+      error (string) - not null if an error occurred 
+    ]
+*/
+function useApi(route, method, body) {
   // Prefix route with production host
-  if (process.env.NODE_ENV === "production") {
-
-  }
   const url = (process.env.NODE_ENV === "production") ? "https://sensehealth-backend.herokuapp.com" + route : route;
   const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     async function getData() {
-      const request = await fetch(url);
-      const data = await request.json();
+      try {
+        const request = await fetch(url, {
+          method: method || 'GET', // Default to GET if no method
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(body)
+        });
 
-      setResult(data);
+        setLoading(false);
+
+        console.log(request.status);
+
+        if (request.status >= 400 && request.status <= 600) {
+          setError(request.status);
+        } else {
+          const data  = await request.json();
+          setResult(data);
+        }
+      } catch (error) {
+        setError(error);
+        setLoading(false);
+      }
     }
 
     getData();
-  }, [url]);
+  }, [url, body, method]);
 
-  return result;
+  return [result, loading, error];
 }
 
 export default useApi;

--- a/src/pages/testApi.js
+++ b/src/pages/testApi.js
@@ -7,7 +7,7 @@ import { routes } from '../utils/constants';
 import '../App.css';
 
 function TestApi() {
-  const response = useApi(routes.TEST_FRONTEND);
+  const [data] = useApi(routes.TEST_FRONTEND);
 
   return (
     <div className="App">
@@ -15,7 +15,7 @@ function TestApi() {
 
       <p>This tests access to our API server, which is hosted on a separate Heroku instance. You should see some generic JSON below</p>
       
-      <code>{JSON.stringify(response) || "If you see this, then API connection failed or is still loading."}</code>
+      <code>{JSON.stringify(data) || "If you see this, then API connection failed or is still loading."}</code>
 
       <br /><br />
 


### PR DESCRIPTION
previously `useApi` only supported simple GET requests

this expands `useApi` to support different types of requests (POST, PUT). also fleshes hook further by returning error and loading indicator